### PR TITLE
Added forked ng-ckeditor + send refresh event on add component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "angular-bootstrap": "~0.12.1",
     "ngDialog": "~0.3.12",
     "lodash": "~3.6.0",
-    "ng-ckeditor": "~0.2.1",
+    "ng-ckeditor": "git@github.com:formio/ng-ckeditor.git",
     "angular-strap": "~2.3.1"
   }
 }

--- a/ngFormBuilder.js
+++ b/ngFormBuilder.js
@@ -136,6 +136,9 @@ app.directive('formBuilder', function() {
           if (!component.key || (component.key.indexOf('.') === -1)) {
             $scope.editComponent(component);
           }
+
+          $scope.$broadcast('ckeditor.refresh');
+
           return component;
         };
 


### PR DESCRIPTION
https://formio.atlassian.net/browse/FA-170

Updating bower dependencies is tricky and I couldn't find a way to have bower download our forked ng-ckeditor (because it's a dep of ngFormBuilder but the ngFormBuilder in formio-app bower points to an older version). But I did test the changes manually and it does fix the issue. This should definitely be tested when updating the ngFormBuilder dependency, though.
