### PR TITLE
FA-222 Fixed deleted resource fields showing up in formBuilder

### DIFF
--- a/ngFormBuilder.js
+++ b/ngFormBuilder.js
@@ -41,7 +41,7 @@ app.directive('formBuilder', function() {
         // Add the components to the scope.
         $scope.formio = new Formio('/app/' + $scope.app);
         $scope.formComponents = formioComponents.components;
-        $scope.formComponentGroups = formioComponents.groups;
+        $scope.formComponentGroups = _.cloneDeep(formioComponents.groups);
         $scope.formComponentsByGroup = _.groupBy($scope.formComponents, function(component) {
           return component.group;
         });


### PR DESCRIPTION
https://formio.atlassian.net/browse/FA-222

'formBuilder' directive was modifying the global formioComponents.groups object. Having it use a deep copy fixes this.
