### PR TITLE
Changed bower dep: ngFormio -> formio

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "tests"
   ],
   "dependencies": {
-    "ngFormio": "git@github.com:formio/ngFormio.git#0.3.8",
+    "formio": "~0.5.3",
     "angular-drag-and-drop-lists": "~1.3.0",
     "angular-bootstrap": "~0.13.0",
     "ngDialog": "~0.3.12",


### PR DESCRIPTION
Depends on bower depenency instead of hardcoding it to an older version. Also fixes conflict with formio-app's dependencies.