### PR TITLE
Form object building: Fixed submit button always being appended to components

### DIFF
--- a/src/directives/formBuilder.js
+++ b/src/directives/formBuilder.js
@@ -30,9 +30,6 @@ module.exports = ['debounce', function(debounce) {
         if (!$scope.form || !$scope.form.components || !$scope.form.components.length) {
           $scope.form = {components:[submitButton]};
         }
-        else {
-          $scope.form.components.push(submitButton);
-        }
         $scope.hideCount = 2;
         $scope.form.page = 0;
         $scope.formio = $scope.src ? new Formio($scope.src) : null;


### PR DESCRIPTION
Any form object loaded, regardless of existing components, would have a submit button appended.
Loading a form from an object now behaves the same as if it was loaded with src; The submit button is only added if their are no existing components.