### PR TITLE
fix(build): exclude lodash from formBuilderConditional.js (#195)

### DIFF
--- a/src/directives/formBuilderConditional.js
+++ b/src/directives/formBuilderConditional.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var utils = require('formio-utils');
 
 module.exports = [


### PR DESCRIPTION
Exclude lodash from formBuilderConditional.js so it will not appear in dependencies free bundle

