### PR TITLE
Upgrade angular-drag-and-drop-lists

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular-drag-and-drop-lists": "^1.4.0",
+    "angular-drag-and-drop-lists": "^2.1.0",
     "angular-bootstrap": "^2.5.0",
     "lodash": "^4.17.4",
     "ng-dialog": "^0.6.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "angular": "^1.6.2",
     "angular-ckeditor": "^0.3.0",
-    "angular-drag-and-drop-lists": "^1.4.0",
+    "angular-drag-and-drop-lists": "^2.1.0",
     "angular-ui-bootstrap": "^2.5.0",
     "formio-utils": "^0.1.10",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Updating the angular-drag-and-drop library should improve performance and introduce a simpler placeholder positioning algorithm.

One case where that matters is on 'dragenter', an optimization was made here https://github.com/marceljuenemann/angular-drag-and-drop-lists/blob/master/angular-drag-and-drop-lists.js#L292

Although it's a major change, it shouldn't break anything according to their release notes.