### PR TITLE
Stop changing non standard formats

### DIFF
--- a/src/components/datetime.js
+++ b/src/components/datetime.js
@@ -21,7 +21,7 @@ module.exports = function(app) {
             if ($scope.component.timePicker.showMeridian) {
                 stdFormatDateTime = 'yyyy-MM-dd hh:mm';
                 stdFormatTime     = 'hh:mm';
-            };
+            }
             var stdFormats        = [stdFormatDateTime, stdFormatDate, stdFormatTime];
 
             if ($scope.component.enableDate && $scope.component.enableTime && stdFormats.indexOf($scope.component.format) !== -1) {

--- a/src/components/datetime.js
+++ b/src/components/datetime.js
@@ -15,14 +15,19 @@ module.exports = function(app) {
           });
 
           $scope.setFormat = function() {
-            if ($scope.component.enableDate && $scope.component.enableTime) {
-              $scope.component.format = 'yyyy-MM-dd HH:mm';
+            var stdFormatDateTime = 'yyyy-MM-dd HH:mm';
+            var stdFormatDate     = 'yyyy-MM-dd';
+            var stdFormatTime     = 'HH:mm';
+            var stdFormats        = [stdFormatDateTime, stdFormatDate, stdFormatTime];
+
+            if ($scope.component.enableDate && $scope.component.enableTime && stdFormats.indexOf($scope.component.format) !== -1) {
+              $scope.component.format = stdFormatDateTime;
             }
-            else if ($scope.component.enableDate && !$scope.component.enableTime) {
-              $scope.component.format = 'yyyy-MM-dd';
+            else if ($scope.component.enableDate && !$scope.component.enableTime && stdFormats.indexOf($scope.component.format) !== -1) {
+              $scope.component.format = stdFormatDate;
             }
-            else if (!$scope.component.enableDate && $scope.component.enableTime) {
-              $scope.component.format = 'HH:mm';
+            else if (!$scope.component.enableDate && $scope.component.enableTime && stdFormats.indexOf($scope.component.format) !== -1) {
+              $scope.component.format = stdFormatTime;
             }
           };
           $scope.startingDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];

--- a/src/components/datetime.js
+++ b/src/components/datetime.js
@@ -79,10 +79,6 @@ module.exports = function(app) {
           {
             name: 'Conditional',
             template: 'formio/components/common/conditional.html'
-          },
-          {
-            name: 'Rules',
-            template: 'formio/components/common/rules.html'
           }
         ],
         documentation: 'http://help.form.io/userguide/#datetime'

--- a/src/components/datetime.js
+++ b/src/components/datetime.js
@@ -18,6 +18,10 @@ module.exports = function(app) {
             var stdFormatDateTime = 'yyyy-MM-dd HH:mm';
             var stdFormatDate     = 'yyyy-MM-dd';
             var stdFormatTime     = 'HH:mm';
+            if ($scope.component.timePicker.showMeridian) {
+                stdFormatDateTime = 'yyyy-MM-dd hh:mm';
+                stdFormatTime     = 'hh:mm';
+            };
             var stdFormats        = [stdFormatDateTime, stdFormatDate, stdFormatTime];
 
             if ($scope.component.enableDate && $scope.component.enableTime && stdFormats.indexOf($scope.component.format) !== -1) {
@@ -75,6 +79,10 @@ module.exports = function(app) {
           {
             name: 'Conditional',
             template: 'formio/components/common/conditional.html'
+          },
+          {
+            name: 'Rules',
+            template: 'formio/components/common/rules.html'
           }
         ],
         documentation: 'http://help.form.io/userguide/#datetime'


### PR DESCRIPTION
Drop a Date/Time component and change the Date Format to something like "MM/dd/yyyy".
Then disable time input on the Time tab.
The format you'd entered will be replaced by the "standard" date format "yyyy-MM-dd".
It would be nice if non-default formats were left as is when enabling or disabling dates and times.
Also takes into account 12/24 hour time when default formats are changed.