### PR TITLE
Added optional data property to the formBuilderList isolate scope.

### DIFF
--- a/src/directives/formBuilderDnd.js
+++ b/src/directives/formBuilderDnd.js
@@ -40,7 +40,9 @@ module.exports = [
     }
 
     // Components depend on this existing
-    $scope.data = {};
+    if (!$scope.data) {
+      $scope.data = {};
+    }
 
     $scope.emit = function() {
       var args = [].slice.call(arguments);

--- a/src/directives/formBuilderList.js
+++ b/src/directives/formBuilderList.js
@@ -10,7 +10,8 @@ module.exports = [
         // drag and drop prompt div
         hideDndBoxCount: '=',
         rootList: '=',
-        options: '='
+        options: '=',
+        data:'=?'
       },
       restrict: 'E',
       replace: true,


### PR DESCRIPTION
I have created a custom component that requires the following change.  I would prefer this change to be merged so I don't have to fork and get behind in future ngFormBuilder updates.

Here is my custom component, it's a layout component that ng-repeats the form it contains.  The data that the component repeats over is determined by the path in the settings modal.  I'm not sure if you want to merge the repeat directive (I can create a separate PR for that), but allowing the formBuilderList to accept an optional data parameter would allow for more powerful custom component creations.

```
module.exports = function(app) {
  app.config([
    'formioComponentsProvider',
    function(formioComponentsProvider) {
      formioComponentsProvider.register('repeat', {
        title: "Repeat",
        template: 'formio/formbuilder/repeat.html',
        group: "layout",
        settings: {
          "key": "repeat",
          "input": false,
          "components": [],
          "tableView": false,
          "type": "repeat",
          "isNew": true
          
        },
        icon: 'fa fa-repeat',
        documentation: '#',
        noDndOverlay: true,
        confirmRemove: true,
        
        views: [
          {
            name: 'Display',
            template: 'formio/components/repeat/display.html'
          },
          {
            name: 'API',
            template: 'formio/components/common/api.html'
          },
          {
            name: 'Conditional',
            template: 'formio/components/common/conditional.html'
          }
        ]
      });
    }
  ])
  .run([
    '$templateCache',
    function($templateCache) {
      $templateCache.put('formio/formbuilder/repeat.html',
        '<div ng-controller="repeat" class="well panel-{{ component.theme }}">' +
          '<div ng-if="builder">' +
            '<form-builder-list component="component" form="form" formio="::formio"></form-builder-list>' +
          '</div>' +
          '<div class="panel-body" ng-repeat="td in data[component.key]" ng-hide="builder">' +
            '<form-builder-list component="td.component" form="td.form" formio="::formio" data="td.data"></form-builder-list>' +
          '</div>' +
        '</div>'
      );
      $templateCache.put('formio/components/repeat/display.html',
        '<ng-form>' +
          '<form-builder-option property="pathToObjToRepeat" label="Path to object to repeat over" placeholder="Enter path in the model to repeat" title="Path to object to repeat over."></form-builder-option>' +
        '</ng-form>'
      );
    }
  ])
  .controller('repeat', ['$scope', function($scope) {
    if ($scope.component && !$scope.component.components) {
      $scope.component.components = [];
    }
    $scope.form = {};

    var dataPath = [];

    //watch for form change
    $scope.$watch('data', function(neww) {
      if (_.isString($scope.component.pathToObjToRepeat)) {
        dataPath = $scope.component.pathToObjToRepeat.split('.');
      }
      
      if (_.has(neww, dataPath)) {
        var targetedData = _.get(neww, dataPath);
        
        //connects repeated forms with submission object in parent scope
        $scope.data[$scope.component.key] = _.map(targetedData, function(data) {
          return {
            form: $scope.form,
            component: $scope.component,
            data: data
          }
        });
      }
    }, true)
    

  }]);
};
```