### PR TITLE
Show something for empty HTML Element components in builder

### DIFF
--- a/src/components/htmlelement.js
+++ b/src/components/htmlelement.js
@@ -27,7 +27,7 @@ module.exports = function(app) {
     '$templateCache',
     function($templateCache) {
       $templateCache.put('formio/formbuilder/htmlelement.html',
-        '<p ng-if="!component.content">HTML Element with no content</p><formio-html-element component="component"></div>'
+        '<p ng-if="!component.content">{{ \'HTML Element with no content\' | formioTranslate }}</p><formio-html-element component="component"></div>'
       );
 
       // Create the settings markup.

--- a/src/components/htmlelement.js
+++ b/src/components/htmlelement.js
@@ -27,7 +27,7 @@ module.exports = function(app) {
     '$templateCache',
     function($templateCache) {
       $templateCache.put('formio/formbuilder/htmlelement.html',
-        '<formio-html-element component="component"></div>'
+        '<p ng-if="!component.content">HTML Element with no content</p><formio-html-element component="component"></div>'
       );
 
       // Create the settings markup.


### PR DESCRIPTION
If user, possibly by accident, creates an HTML Element component with no content the component will be added to the form but will be invisible.  There will be no pop up buttons to edit settings, move or delete the component.

Added place holder paragraph to show something for empty component in the builder.