### PR TITLE
Removed double tool tip

### DIFF
--- a/src/components/resource.js
+++ b/src/components/resource.js
@@ -71,7 +71,6 @@ module.exports = function(app) {
             '<label for="template" form-builder-tooltip="The HTML template for the result data items.">{{\'Item Template\' | formioTranslate}}</label>' +
             '<textarea class="form-control" id="template" name="template" ng-model="component.template" rows="3">{{ component.template }}</textarea>' +
           '</div>' +
-          '<form-builder-option property="tooltip"></form-builder-option>' +
           '<form-builder-option property="errorLabel"></form-builder-option>' +
           '<form-builder-option property="customClass"></form-builder-option>' +
           '<form-builder-option property="tabindex"></form-builder-option>' +


### PR DESCRIPTION
Line 57 already has <form-builder-option property="tooltip"></form-builder-option>. Removing it fixed GUI displaying the tooltip field twice