### PR TITLE
Select Component - Change end tag on the select component element

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -188,7 +188,7 @@ module.exports = function(app) {
             '<div ng-switch-when="url">' +
             '  <form-builder-option property="data.url" label="Data Source URL" placeholder="Data Source URL" title="A URL that returns a JSON array to use as the data source."></form-builder-option>' +
             '</div>' +
-            '<value-builder ng-switch-when="url" data=component.data.headers label="Request Headers" tooltip-text="Set any headers that should be sent along with the request to the url. This is useful for authentication." label-label="Key" label-property="key" />' +
+            '<value-builder ng-switch-when="url" data=component.data.headers label="Request Headers" tooltip-text="Set any headers that should be sent along with the request to the url. This is useful for authentication." label-label="Key" label-property="key"></value-builder>' +
             '<value-builder ng-switch-when="values" data="component.data.values" label="Data Source Values" tooltip-text="Values to use as the data source. Labels are shown in the select field. Values are the corresponding values saved with the submission."></value-builder>' +
             '<div class="form-group" ng-switch-when="resource">' +
             '<label for="placeholder" form-builder-tooltip="The resource to be used with this field.">{{\'Resource\' | formioTranslate}}</label>' +


### PR DESCRIPTION
My team came across an issue using the select component. 

When trying to use the 'Values' data source type, the table that should generate so you can input your 'Label' and 'Value's would not show. I dug into the DOM and saw that the table / that entire element was not there.
 
![image](https://user-images.githubusercontent.com/22038038/36914450-5d3a695e-1e1b-11e8-9847-23b384926451.png)


I checked the lib to make sure it was there, and it was. I played around with it and found that if I changed it from a void tag to a closing tag, it would work. 

I have looked around the rest of the code base and saw that using the full closing tag is convention.