### PR TITLE
Add Properties to Selectboxes component

### DIFF
--- a/src/components/selectboxes.js
+++ b/src/components/selectboxes.js
@@ -42,7 +42,6 @@ module.exports = function(app) {
           '<form-builder-option-options-label-position></form-builder-option-options-label-position>' +
           '<form-builder-option property="tooltip"></form-builder-option>' +
           '<value-builder-with-shortcuts form="form" component="component" data="component.values" default="component.defaultValue" label="Values" tooltip-text="The radio button values that can be picked for this field. Values are text submitted with the form data. Labels are text that appears next to the radio buttons on the form."></value-builder-with-shortcuts>' +
-          '<form-builder-option property="tooltip"></form-builder-option>' +
           '<form-builder-option property="errorLabel"></form-builder-option>' +
           '<form-builder-option property="customClass"></form-builder-option>' +
           '<form-builder-option property="tabindex"></form-builder-option>' +

--- a/src/components/selectboxes.js
+++ b/src/components/selectboxes.js
@@ -42,6 +42,7 @@ module.exports = function(app) {
           '<form-builder-option-options-label-position></form-builder-option-options-label-position>' +
           '<form-builder-option property="tooltip"></form-builder-option>' +
           '<value-builder-with-shortcuts form="form" component="component" data="component.values" default="component.defaultValue" label="Values" tooltip-text="The radio button values that can be picked for this field. Values are text submitted with the form data. Labels are text that appears next to the radio buttons on the form."></value-builder-with-shortcuts>' +
+          '<form-builder-option property="tooltip"></form-builder-option>' +
           '<form-builder-option property="errorLabel"></form-builder-option>' +
           '<form-builder-option property="customClass"></form-builder-option>' +
           '<form-builder-option property="tabindex"></form-builder-option>' +
@@ -62,7 +63,12 @@ module.exports = function(app) {
       // Create the API markup.
       $templateCache.put('formio/components/selectboxes/api.html',
         '<ng-form>' +
-          '<form-builder-option-key></form-builder-option-key>' +
+        '<form-builder-option-key></form-builder-option-key>' +
+        '<uib-accordion>' +
+        '<div uib-accordion-group heading="Custom Properties" class="panel panel-default">' +
+        '<object-builder data="component.properties" label="Custom Properties" tooltip-text="This allows you to configure any custom properties for this component." />' +
+        '</div>' +
+        '</uib-accordion>' +
         '</ng-form>'
       );
 


### PR DESCRIPTION
This is to add the properties field to selectboxes component.
Before : 
![image](https://user-images.githubusercontent.com/14008272/43601707-dc8d06cc-965b-11e8-84f8-c416e4ca078e.png)
The api tab does not have the properties field

After:
![image](https://user-images.githubusercontent.com/14008272/43601783-12b873b2-965c-11e8-9aaf-a7ded0412567.png)
There are custom properties in select boxes
