### PR TITLE
Use angular-ck-editor-legacy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "ng-dialog": "^1.4.0",
     "ng-formio": "^2.37.3",
     "ng-tags-input": "^3.2.0",
-    "angular-ckeditor": "^1.0.3"
+    "angular-ckeditor-legacy": "^1.0.3"
   },
   "devDependencies": {
     "font-awesome": "^4.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,10 +100,6 @@
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.8.tgz",
       "integrity": "sha512-wtef/y4COxM7ZVhddd7JtAAhyYObq9YXKar9tsW7558BImeVYteJiTxCKeJOL45lJ/+7B4wrAC49j8gTFYEthg=="
     },
-    "angular-ckeditor": {
-      "version": "github:lemonde/angular-ckeditor#655d52844515351a1c4f599f546dc2c5cf8cc44b",
-      "from": "github:lemonde/angular-ckeditor#v1.0.3"
-    },
     "angular-ckeditor-legacy": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/angular-ckeditor-legacy/-/angular-ckeditor-legacy-1.0.3.tgz",
@@ -3426,8 +3422,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3448,14 +3443,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3470,20 +3463,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3600,8 +3590,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3613,7 +3602,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3628,7 +3616,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3636,14 +3623,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3662,7 +3647,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3743,8 +3727,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3756,7 +3739,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3842,8 +3824,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3879,7 +3860,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3899,7 +3879,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3943,14 +3922,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "angular": "^1.7.8",
-    "angular-ckeditor": "github:lemonde/angular-ckeditor#v1.0.3",
+    "angular-ckeditor-legacy": "^1.0.3",
     "angular-drag-and-drop-lists": "^2.1.0",
     "angular-ui-bootstrap": "^2.5.6",
     "formiojs": "^3.23.1",


### PR DESCRIPTION
Related to this PR https://github.com/formio/ngFormio/pull/644

ngFormioBuilder is a dependency of ngFormio, so, when installing ngFormio it is still calling bower because ngFormBuilder is pulling lemonde/angular-ckeditor