### PR TITLE
Remove reference to jquery.inputmask

### DIFF
--- a/src/constants/commonOptions.js
+++ b/src/constants/commonOptions.js
@@ -49,7 +49,7 @@ module.exports = {
   inputMask: {
     label: 'Input Mask',
     placeholder: 'Input Mask',
-    tooltip: 'An input mask helps the user with input by ensuring a predefined format.<br><br>9: numeric<br>a: alphabetical<br>*: alphanumeric<br><br>Example telephone mask: (999) 999-9999<br><br>See the <a target=\'_blank\' href=\'https://github.com/RobinHerbots/jquery.inputmask\'>jquery.inputmask documentation</a> for more information.</a>'
+    tooltip: 'An input mask helps the user with input by ensuring a predefined format.<br><br>9: numeric<br>a: alphabetical<br>*: alphanumeric<br><br>Example telephone mask: (999) 999-9999'
   },
   format: {
     label: 'Format',


### PR DESCRIPTION
I don't know if this was used at some point or if it is in some way used internally, but in any case, very frustratingly so, non of the functionality documented in the linked repo is actually exposed.